### PR TITLE
Adds easy output filtering based on category order.

### DIFF
--- a/src/docs/save.md
+++ b/src/docs/save.md
@@ -6,6 +6,8 @@ are `HTML` and `markdown`.
 
 *General Options*
 
+* `category_order` (default: `:module, :function, :method, :type, :typealias, :macro, :global, :comment`)
+  Categories  to include in the output in the defined order.
 * `include_internal` (default: `true`): To exclude documentation for non-exported objects,
   the keyword argument `include_internal = false` should be set. This is only supported for
   `markdown`.

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -1,5 +1,6 @@
 ## Various methods for filtering and sorting Metadata
 
+const CATEGORY_ORDER = [:module, :function, :method, :type, :typealias, :macro, :global]
 
 """
 Filter Metadata based on categories or file source

--- a/src/render.jl
+++ b/src/render.jl
@@ -8,6 +8,7 @@ const MDSTYLETAGS = ["", "*", "**"]
 
 type Config
     # General Options
+    category_order   :: Vector{Symbol}
     include_internal :: Bool
     # Html only Options
     mathjax          :: Bool
@@ -20,6 +21,8 @@ type Config
 
     const fields   = fieldnames(Config)
     const defaults = Dict{Symbol, Any}([
+        (:category_order   , [:module, :function, :method, :type, :typealias, :macro, :global,
+                                                                                    :comment]),
         (:include_internal , true),
         (:mathjax          , false),
         (:mdstyle_header   , "#"),
@@ -55,8 +58,6 @@ function save(file::String, modulename::Module; args...)
     mime = MIME("text/$(strip(last(splitext(file)), '.'))")
     save(file, mime, documentation(modulename), config)
 end
-
-const CATEGORY_ORDER = [:module, :function, :method, :type, :macro, :global]
 
 # Dispatch container for metadata display.
 type Meta{keyword}

--- a/src/render/html.jl
+++ b/src/render/html.jl
@@ -52,7 +52,7 @@ function writehtml(io::IO, doc::Metadata, config::Config)
 
         ents = Entries()
         wrap(io, "ul", "class='index'") do
-            for k in CATEGORY_ORDER
+            for k in config.category_order
                 haskey(index, k) || continue
                 wrap(io, "li") do
                     println(io, "<strong>$(k)s:</strong>")

--- a/src/render/md.jl
+++ b/src/render/md.jl
@@ -44,7 +44,7 @@ function writemd(io::IO, doc::Metadata, config::Config)
 
     if !isempty(index)
         ents = Entries()
-        for k in CATEGORY_ORDER
+        for k in config.category_order
             haskey(index, k) || continue
             for (s, obj) in index[k]
                 push!(ents, modulename(doc), obj, entries(doc)[obj])


### PR DESCRIPTION
Moves CATEGORY_ORDER to Config to allow easy output filtering based on
category.

Works for `html` and `markdown`.

Keeps `filtering` as it was.
